### PR TITLE
Perf add bond

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ criterion = { version = "0.8.2", features = ["html_reports"]}
 name = "my_benchmark"
 harness = false
 
+[[bench]]
+name = "tng"
+harness = false
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/benches/tng.rs
+++ b/benches/tng.rs
@@ -1,0 +1,14 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use std::path::Path;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Benchmark TNG format (large file: 38376 atoms × 6 frames)
+    let tng_path = Path::new("./src/tests-data/tng/1aki.tng");
+    c.bench_function("read 1aki.tng", |b| {
+        b.iter(|| black_box(molio::read_trajectory(tng_path)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -4,7 +4,7 @@
 //
 // See LICENSE at the project root for full text.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     angle::Angle,
@@ -14,10 +14,10 @@ use crate::{
     improper::Improper,
 };
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Connectivity {
-    /// Bonds in this connectivity
-    pub(crate) bonds: BTreeSet<Bond>,
+    /// Bonds and their orders in this connectivity (sorted by Bond for consistent iteration)
+    pub(crate) bonds: BTreeMap<Bond, BondOrder>,
 
     /// Angles in this connectivity
     pub(crate) angles: BTreeSet<Angle>,
@@ -27,9 +27,6 @@ pub struct Connectivity {
 
     /// Impropers in this connectivity
     pub(crate) impropers: BTreeSet<Improper>,
-
-    /// Bond orders in this connectivity
-    pub(crate) bond_orders: Vec<BondOrder>,
 
     /// Is the cached content up to date?
     up_to_date: bool,
@@ -71,9 +68,6 @@ impl Connectivity {
     pub fn add_bond(&mut self, i: usize, j: usize, bond_order: BondOrder) {
         self.up_to_date = false;
 
-        let bond = Bond::new(i, j);
-        let was_new = self.bonds.insert(bond);
-
         if i > self.biggest_atom {
             self.biggest_atom = i;
         }
@@ -82,41 +76,23 @@ impl Connectivity {
             self.biggest_atom = j;
         }
 
-        if was_new {
-            let diff = self
-                .bonds
-                .iter()
-                .position(|b| *b == bond)
-                .expect("we just inserted the element");
-            self.bond_orders.insert(diff, bond_order);
-        }
+        self.bonds.entry(Bond::new(i, j)).or_insert(bond_order);
     }
 
     pub fn remove_bond(&mut self, i: usize, j: usize) {
         let bond = Bond::new(i, j);
-        let pos = self.bonds.iter().position(|b| *b == bond);
-
-        if let Some(found_pos) = pos {
+        if self.bonds.remove(&bond).is_some() {
             self.up_to_date = false;
-            self.bonds.remove(&bond);
-
-            self.bond_orders.remove(found_pos);
-
-            debug_assert_eq!(self.bond_orders.len(), self.bonds.len());
         }
     }
 
     pub fn bond_order(&self, i: usize, j: usize) -> Result<BondOrder, CError> {
         let bond = Bond::new(i, j);
-        self.bonds
-            .iter()
-            .position(|b| *b == bond)
-            .map(|pos| self.bond_orders[pos])
-            .ok_or_else(|| {
-                CError::GenericError(format!(
-                    "out of bounds atomic index. No bond between {i} and {j} exists"
-                ))
-            })
+        self.bonds.get(&bond).copied().ok_or_else(|| {
+            CError::GenericError(format!(
+                "out of bounds atomic index. No bond between {i} and {j} exists"
+            ))
+        })
     }
 
     fn recalculate(&mut self) {
@@ -128,7 +104,7 @@ impl Connectivity {
         let mut bonded_to = vec![Vec::with_capacity(4); self.biggest_atom + 1];
 
         // Generate the list of which atom is bonded to which one
-        for bond in &self.bonds {
+        for bond in self.bonds.keys() {
             debug_assert!(bond[0] < bonded_to.len());
             debug_assert!(bond[1] < bonded_to.len());
             bonded_to[bond[0]].push(bond[1]);
@@ -136,7 +112,7 @@ impl Connectivity {
         }
 
         // Generate list of angles
-        for bond in &self.bonds {
+        for bond in self.bonds.keys() {
             let i = bond[0];
             let j = bond[1];
 
@@ -194,7 +170,7 @@ mod tests {
 
         // Check that the bond was added
         assert_eq!(connectivity.bonds.len(), 1);
-        assert!(connectivity.bonds.contains(&Bond::new(1, 2)));
+        assert!(connectivity.bonds.contains_key(&Bond::new(1, 2)));
 
         // Check bond order
         assert_eq!(connectivity.bond_order(1, 2).unwrap(), BondOrder::Single);
@@ -226,14 +202,11 @@ mod tests {
         // Remove a bond
         connectivity.remove_bond(1, 2);
         assert_eq!(connectivity.bonds.len(), 2);
-        assert!(!connectivity.bonds.contains(&Bond::new(1, 2)));
+        assert!(!connectivity.bonds.contains_key(&Bond::new(1, 2)));
 
         // Removing a non-existent bond should do nothing
         connectivity.remove_bond(1, 2);
         assert_eq!(connectivity.bonds.len(), 2);
-
-        // Check that bond orders array has same length as bonds set
-        assert_eq!(connectivity.bond_orders.len(), connectivity.bonds.len());
     }
 
     #[test]

--- a/src/connectivity.rs
+++ b/src/connectivity.rs
@@ -79,6 +79,7 @@ impl Connectivity {
         self.bonds.entry(Bond::new(i, j)).or_insert(bond_order);
     }
 
+    /// Remove a bond between the atoms `i` and `j`
     pub fn remove_bond(&mut self, i: usize, j: usize) {
         let bond = Bond::new(i, j);
         if self.bonds.remove(&bond).is_some() {
@@ -86,6 +87,7 @@ impl Connectivity {
         }
     }
 
+    /// Get the bond order of the bond between `i` and `j`
     pub fn bond_order(&self, i: usize, j: usize) -> Result<BondOrder, CError> {
         let bond = Bond::new(i, j);
         self.bonds.get(&bond).copied().ok_or_else(|| {
@@ -95,6 +97,7 @@ impl Connectivity {
         })
     }
 
+    /// Recalculate the angles and the dihedrals from the bond list
     fn recalculate(&mut self) {
         self.angles.clear();
         self.dihedrals.clear();

--- a/src/formats/amber.rs
+++ b/src/formats/amber.rs
@@ -628,7 +628,7 @@ impl AMBERTrajFormat {
             self.n_atoms = frame.size();
             self.has_velocities = frame.velocities().is_some();
             if let Some(Property::String(name)) = frame.properties.get("name") {
-                self.file_title = name.clone();
+                self.file_title.clone_from(name);
             }
             self.initialized = true;
         }
@@ -872,11 +872,11 @@ mod tests {
         assert_eq!(frame.properties.get("name"), None);
 
         let positions = frame.positions();
-        assert_approx_eq!(positions[0][0], 0.2990952, 1e-4);
+        assert_approx_eq!(positions[0][0], 0.299_095_2, 1e-4);
         assert_approx_eq!(positions[0][1], 8.31003, 1e-4);
         assert_approx_eq!(positions[0][2], 11.72146, 1e-4);
 
-        assert_approx_eq!(positions[296][0], 6.797599, 1e-4);
+        assert_approx_eq!(positions[296][0], 6.797_599, 1e-4);
         assert_approx_eq!(positions[296][1], 11.50882, 1e-4);
         assert_approx_eq!(positions[296][2], 12.70423, 1e-4);
 
@@ -890,11 +890,11 @@ mod tests {
         }
 
         let positions = frame.positions();
-        assert_approx_eq!(positions[0][0], 0.3185586, 1e-4);
-        assert_approx_eq!(positions[0][1], 8.776042, 1e-4);
+        assert_approx_eq!(positions[0][0], 0.318_558_6, 1e-4);
+        assert_approx_eq!(positions[0][1], 8.776_042, 1e-4);
         assert_approx_eq!(positions[0][2], 11.8927, 1e-4);
 
-        assert_approx_eq!(positions[296][0], 7.089802, 1e-4);
+        assert_approx_eq!(positions[296][0], 7.089_802, 1e-4);
         assert_approx_eq!(positions[296][1], 10.35007, 1e-4);
         assert_approx_eq!(positions[296][2], 12.8159, 1e-4);
 
@@ -944,7 +944,7 @@ mod tests {
 
         let velocities = frame.velocities().unwrap();
         assert_approx_eq!(velocities[1400][0], 0.6854_072 * -0.856, 1e-4);
-        assert_approx_eq!(velocities[1400][1], 0.09196_011 * -0.856, 1e-4);
+        assert_approx_eq!(velocities[1400][1], 0.091_960_11 * -0.856, 1e-4);
         assert_approx_eq!(velocities[1400][2], 2.260_214 * -0.856, 1e-4);
 
         assert_approx_eq!(velocities[1600][0], -0.3342_645 * -0.856, 1e-4);

--- a/src/formats/tng.rs
+++ b/src/formats/tng.rs
@@ -32,7 +32,7 @@ impl TNGFile {
                         "could not open file at '{}'",
                         path.to_string_lossy()
                     )));
-                };
+                }
             }
             'w' | 'a' => {
                 traj.last_program_name_set("molio");
@@ -162,7 +162,7 @@ impl TNGFormat {
             frame
                 .properties
                 .insert("time".into(), crate::property::Property::Double(0.0));
-        };
+        }
 
         self.read_positions(&mut frame)?;
         self.read_velocities(&mut frame)?;
@@ -264,7 +264,7 @@ impl TNGFormat {
                     crate::bond::BondOrder::Unknown,
                 )?;
             }
-        };
+        }
 
         frame.set_topology(topology)?;
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -67,7 +67,7 @@ impl Frame {
 
     /// Set the frame index to [`index`]
     pub fn set_frame_index(&mut self, index: usize) {
-        self.index = index
+        self.index = index;
     }
 
     /// Get a const reference to the topology of this frame

--- a/src/residue.rs
+++ b/src/residue.rs
@@ -72,6 +72,7 @@ impl Residue {
     }
 
     /// Checks whether [`Self`] is empty.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.atoms.is_empty()
     }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -57,6 +57,7 @@ impl Topology {
     }
 
     /// Checks whether [`Self`] is empty.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.atoms.is_empty()
     }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -20,7 +20,7 @@ use crate::{
     residue::Residue,
 };
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Topology {
     /// Atoms in the system
     pub atoms: Vec<Atom>,
@@ -67,7 +67,7 @@ impl Topology {
     /// # Errors
     /// Returns an error if any existing bond references an atom index >= `size`.
     pub fn resize(&mut self, size: usize) -> Result<(), CError> {
-        for bond in &self.connect.bonds {
+        for bond in self.connect.bonds.keys() {
             if bond[0] >= size || bond[1] >= size {
                 return Err(CError::GenericError(format!(
                     "can not resize the topology to contain {size} as there is a bond between atoms {} - {}",
@@ -90,7 +90,7 @@ impl Topology {
     /// Returns a vector of all bonds present in the topology.
     #[must_use]
     pub fn bonds(&self) -> Vec<Bond> {
-        self.connect.bonds.iter().copied().collect()
+        self.connect.bonds.keys().copied().collect()
     }
 
     /// Returns a vector of all angles present in the topology.
@@ -196,7 +196,7 @@ impl Topology {
         for &bond_i in first {
             for &bond_j in second {
                 let check_bond = Bond::new(bond_i, bond_j);
-                if self.connect.bonds.contains(&check_bond) {
+                if self.connect.bonds.contains_key(&check_bond) {
                     return true;
                 }
             }
@@ -205,8 +205,8 @@ impl Topology {
     }
 
     #[must_use]
-    pub fn bond_orders(&self) -> &Vec<BondOrder> {
-        &self.connect.bond_orders
+    pub fn bond_orders(&self) -> Vec<BondOrder> {
+        self.connect.bonds.values().copied().collect()
     }
 }
 

--- a/src/trajectory.rs
+++ b/src/trajectory.rs
@@ -185,6 +185,7 @@ impl TrajectoryReader {
     }
 
     /// Returns the number of frames in [`Self`].
+    #[must_use]
     pub fn len(&self) -> usize {
         self.size
     }


### PR DESCRIPTION
ups the performance of add_bond by changing from a btreeset to a btreemap. chemfiles uses a sorted_set which is backed by a std::vec